### PR TITLE
[3.5] ABI refactoring

### DIFF
--- a/contracts/Mocks/MockDai.sol
+++ b/contracts/Mocks/MockDai.sol
@@ -5,7 +5,7 @@ import "../../node_modules/openzeppelin-solidity/contracts/token/ERC20/ERC20.sol
 
 contract MockDai is ERC20 {
 
-    constructor() public { 
+    constructor() public {
         _mint(msg.sender, 1000000 ether);
     }
 

--- a/contracts/SolidifiedBugBounty.sol
+++ b/contracts/SolidifiedBugBounty.sol
@@ -40,24 +40,35 @@ contract SolidifiedBugBounty {
         uint256 commitPeriod;
     }
 
-    uint256 constant public automaticApproval = 3 days; 
-    uint256 constant public arbitrationFee = 10 ether;
-    uint256 constant public votingFee = 10 ether;
-    uint256 internal projectCount;
-    address public dai;
-    mapping(address => uint256) public balances;
-    mapping(uint256 => bytes32) public projectIdtoHash;
-    mapping(uint256 => Project) public projects; //Owner => Id => Project
-    mapping(uint256 => mapping(uint256 => Bug)) public bugs; //ProjectId => BugId => Bug
-    mapping(uint256 => uint256) public bugCount;
-    mapping(uint256 => mapping(uint256 => mapping(uint256 => Proposal))) public proposals; //Project Id, Bug Id, Index Proposal
-    mapping(uint256 => mapping(uint256 => Arbitration)) public arbitrations;
-    mapping(bytes32 => mapping(address => bytes32)) public commits;
-    mapping(bytes32 => mapping(address => uint)) public votes; 
-    mapping(uint256 => mapping(uint256 => uint256)) public proposalCount;
-    mapping(bytes32 => uint256) public objectBalances; //Non-address balances. For Projects is SHA3(owner, projectID), for Bugs is SHA3(ProjectHash, bugId), for arbitration is SHA3(projectHash, bugHash);
+    uint256 constant public INTERIM = 3 days;
+    uint256 constant public ARBITRATION_FEE = 10 ether;
+    uint256 constant public VOTING_FEE = 10 ether;
+    uint256 constant public BUG_STAKE = 10;
 
-    event ProjectPosted();
+    address public dai;
+
+    mapping(address => uint256) public balances;
+    mapping(bytes32 => uint256) public objectBalances;
+
+    mapping(uint256 => bytes32) public projectNumberToId;
+    mapping(uint256 => mapping(uint256 => bytes32)) public bugNumberToId;
+    mapping(uint256 => mapping(uint256 => bytes32)) public arbitrationNumberToId;
+
+    mapping(bytes32 => Project) public projects;
+    mapping(bytes32 => Bug) public bugs;
+    mapping(bytes32 => Arbitration) public arbitrations;
+    mapping(bytes32 => mapping(uint256 => Proposal)) public proposals;
+
+    mapping(bytes32 => uint256) public bugCount;
+    mapping(bytes32 => uint256) public proposalCount;
+    uint256 internal projectCount;
+
+    mapping(bytes32 => mapping(address => bytes32)) public commits;
+    mapping(bytes32 => mapping(address => uint)) public votes;
+
+    event ProjectPosted(bytes32 Id, address Owner);
+    event ProjectPulled(bytes32 Id, address Owner, uint256 time);
+    event BugPosted(bytes32 projectId, bytes32 bugId, address hunter);
     event Deposit();
     event Withdraw();
     event BugAccepted();
@@ -77,8 +88,8 @@ contract SolidifiedBugBounty {
     }
 
     function withdraw(uint256 _amount) public {
-        require(balances[msg.sender] >= _amount);
-        require(IERC20(dai).transfer(msg.sender,_amount));
+        require(balances[msg.sender] >= _amount, "Not enough funds");
+        require(IERC20(dai).transfer(msg.sender,_amount), "External call Falied");
         balances[msg.sender] = balances[msg.sender].sub(_amount);
         emit Withdraw();
     }
@@ -102,143 +113,133 @@ contract SolidifiedBugBounty {
     function sendToAddress(bytes32 origin, address dest, uint256 _amount) internal {
         objectBalances[origin] = objectBalances[origin].sub(_amount);
         balances[dest] = balances[dest].add(_amount);
-        
     }
     /**
             Contract Posting Functions
     **/
-    function postProject(bytes32 ipfsHash, uint256 totalPool, uint256[5] memory _rewardsValue) public returns(uint256 projectId){
+    function postProject(bytes32 ipfsHash, uint256 totalPool, uint256[5] memory _rewardsValue) public returns(bytes32 projectId){
         require(isOrdered(_rewardsValue), "Rewards must be ordered");
         require(totalPool >= _rewardsValue[0], "totalPool should be greater than critical reward");
-        projectId = projectCount;
+        uint256 projectNumber = projectCount;
+        projectCount++;
+        projectId = keccak256(abi.encodePacked(msg.sender, projectNumber));
         projects[projectId] = Project(msg.sender, ipfsHash, ProjectStatus.active);
         for(uint i = 0; i < _rewardsValue.length; i++){
             projects[projectId].rewards[i] = _rewardsValue[i];
         }
-        bytes32 projectHash = keccak256(abi.encodePacked(msg.sender, projectId));
-        projectIdtoHash[projectId] = projectHash;
-        sendToObject(msg.sender, projectHash, totalPool);
-        emit ProjectPosted();
-        projectCount++;
-    }
-    
-    function pullProject(uint256 projectId) public {
-        require(msg.sender == projects[projectId].owner, "Not authorized");
-        bytes32 projectHash = projectIdtoHash[projectId];
-        sendToAddress(projectHash, msg.sender, objectBalances[projectHash]);
-        projects[projectId].status = ProjectStatus.closed;
+        projectNumberToId[projectNumber] = projectId;
+        sendToObject(msg.sender, projectId, totalPool);
+        emit ProjectPosted(projectId, msg.sender);
     }
 
-    function increasePool(uint256 projectId, uint256 _amount) public {
+    function pullProject(bytes32 projectId) public {
         require(msg.sender == projects[projectId].owner, "Not authorized");
-        bytes32 projectHash = projectIdtoHash[projectId];
-        sendToObject(msg.sender, projectHash, _amount);
-        if(objectBalances[projectIdtoHash[projectId]] >= projects[projectId].rewards[0]){
-            projects[projectId].status = ProjectStatus.active;
-        }
+        sendToAddress(projectId, msg.sender, objectBalances[projectId]);
+        projects[projectId].status = ProjectStatus.closed;
+        emit ProjectPulled(projectId, msg.sender, now);
     }
-    
+
+
+    function increasePool(bytes32 projectId, uint256 _amount) public {
+        require(msg.sender == projects[projectId].owner, "Not authorized");
+        sendToObject(msg.sender, projectId, _amount);
+        if (objectBalances[projectId] >= projects[projectId].rewards[0])
+            projects[projectId].status = ProjectStatus.active;
+    }
+
     /**
             Bug Functions
     **/
-    function postBug(bytes32 bugDescription, uint256 projectId, Severity severity) public {
-        uint256 bugId = bugCount[projectId];
+    function postBug(bytes32 bugDescription, bytes32 projectId, Severity severity) public returns(bytes32 bugId) {
+        uint256 bugNumber = bugCount[projectId];
         uint256 bugValue = projects[projectId].rewards[uint256(severity)];
-        bugs[projectId][bugId] = Bug(msg.sender, now, bugValue, BugStatus.pending, severity);
-        bytes32 bugHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugId));
-        sendToObject(msg.sender, bugHash, bugValue.div(10));
-        __transfer(projectIdtoHash[projectId], bugHash, bugValue);
-        bugCount[projectId] = bugCount[projectId].add(1);
-        if(objectBalances[projectIdtoHash[projectId]] < projects[projectId].rewards[0]){
+        bugId = keccak256(abi.encodePacked(projects[projectId], bugNumber));
+        bugs[bugId] = Bug(msg.sender, now, bugValue, BugStatus.pending, severity);
+        sendToObject(msg.sender, bugId, bugValue.div(BUG_STAKE));
+        __transfer(projectId, bugId, bugValue);
+        bugNumber[projectId] = bugNumber[projectId].add(1);
+        if(objectBalances[projectId] < projects[projectId].rewards[0]){
             projects[projectId].status = ProjectStatus.unfunded;
         }
+        emit BugPosted(projectId, bugId, msg.sender);
     }
 
-    function acceptBug(uint256 projectId, uint256 bugId) public {
+    function acceptBug(bytes32 projectId, bytes32 bugId) public {
         require(msg.sender == projects[projectId].owner, "Not authorized");
-        require(bugs[projectId][bugId].status == BugStatus.pending);
+        require(bugs[bugId].status == BugStatus.pending, "Bug in the wrong status");
        _acceptBug(projectId, bugId);
     }
 
-    function timeoutAcceptBug(uint256 projectId, uint256 bugId) public {
-        require(now.sub(bugs[projectId][bugId].timestamp) >= automaticApproval);
-        require(bugs[projectId][bugId].status == BugStatus.pending);
+    function timeoutAcceptBug(bytes32 projectId, bytes32 bugId) public {
+        require(now.sub(bugs[bugId].timestamp) >= INTERIM, "No correct time");
+        require(bugs[bugId].status == BugStatus.pending, "Bug should be pending" );
         _acceptBug(projectId, bugId);
     }
 
-    function rejectBug(uint256 projectId, uint256 bugId, bytes32 justification, Severity severity) public {
+    function rejectBug(bytes32 projectId, bytes32 bugId, bytes32 justification, Severity severity) public {
         require(msg.sender == projects[projectId].owner, "Not authorized");
-        bugs[projectId][bugId].status = BugStatus.negotiation;
-        proposalCount[projectId][bugId]++;
-        proposals[projectId][bugId][proposalCount[projectId][bugId]] = Proposal(severity, now, justification, msg.sender);
+        bugs[bugId].status = BugStatus.negotiation;
+        proposalCount[bugId]++;
+        proposals[bugId][proposalCount[bugId]] = Proposal(severity, now, justification, msg.sender);
     }
 
-    /** 
-        TODO The following functions are nasty... a lot of refactor is needed 
+    /**
+        TODO The following functions are nasty... a lot of refactor is needed
     **/
 
-    function acceptProposal(uint256 projectId, uint256 bugId) public {
-        address turn = proposalCount[projectId][bugId] % 2 == 0 ? projects[projectId].owner : bugs[projectId][bugId].hunter;
-        require(msg.sender == turn || (now.sub(proposals[projectId][bugId][proposalCount[projectId][bugId]].timestamp) > automaticApproval));
-        Proposal memory proposal = proposals[projectId][bugId][proposalCount[projectId][bugId]];
-        Bug memory bug = bugs[projectId][bugId];
-        uint depositDiff = bug.value.div(10).sub(projects[projectId].rewards[uint256(proposal.severity)].div(10));
+    function acceptProposal(bytes32 projectId, bytes32 bugId) public {
+        (address turn , ) = inTurn(projectId, bugId);
+        require(msg.sender == turn || (now.sub(proposals[bugId][proposalCount[bugId]].timestamp) > INTERIM));
+        Proposal memory proposal = proposals[bugId][proposalCount[bugId]];
+        Bug memory bug = bugs[bugId];
+        uint depositDiff = bug.value.div(BUG_STAKE).sub(projects[projectId].rewards[uint256(proposal.severity)].div(BUG_STAKE));
         bug.value = projects[projectId].rewards[uint256(proposal.severity)];
-        bugs[projectId][bugId] = bug;
+        bugs[bugId] = bug;
         _acceptBug(projectId, bugId);
-        bytes32 bugHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugId));
-        sendToAddress(bugHash,bug.hunter, depositDiff);
-        __transfer(bugHash, projectIdtoHash[projectId],objectBalances[bugHash]);
+        sendToAddress(bugId,bug.hunter, depositDiff);
+        __transfer(bugId, projectId, objectBalances[bugId]);
     }
 
-    function _acceptBug(uint256 _projectId, uint256 _bugId) internal {
-        Bug memory bug = bugs[_projectId][_bugId];
+    function _acceptBug(bytes32 _projectId, bytes32 _bugId) internal {
+        Bug memory bug = bugs[_bugId];
         bug.status = BugStatus.accepted;
-        bytes32 bugHash = keccak256(abi.encodePacked(projectIdtoHash[_projectId], _bugId));
-        sendToAddress(bugHash,bug.hunter, bug.value.add(bug.value.div(10)));
-        bugs[_projectId][_bugId] = bug;
+        sendToAddress(_bugId,bug.hunter, bug.value.add(bug.value.div(BUG_STAKE)));
+        bugs[_bugId] = bug;
         emit BugAccepted();
     }
 
-    function counterProposal(uint256 projectId, uint256 bugId, bytes32 justification, Severity severity) public {
-        address turn = proposalCount[projectId][bugId] % 2 == 0 ? projects[projectId].owner : bugs[projectId][bugId].hunter;
-        require(msg.sender == turn);
-        proposalCount[projectId][bugId]++;
-        proposals[projectId][bugId][proposalCount[projectId][bugId]] = Proposal(severity, now, justification, msg.sender);
+    function counterProposal(bytes32 projectId, bytes32 bugId, bytes32 justification, Severity severity) public {
+       (address proposer,) = inTurn(projectId, bugId);
+        require(msg.sender == proposer, "Not current proposer");
+        proposalCount[bugId]++;
+        proposals[bugId][proposalCount[bugId]] = Proposal(severity, now, justification, msg.sender);
     }
 
     /**
             Arbitration Functions
     **/
-    function sendToArbitration(uint256 projectId,uint256 bugId) public {
-        require(proposalCount[projectId][bugId] > 1);
-        address turn = proposalCount[projectId][bugId] % 2 == 0 ? projects[projectId].owner : bugs[projectId][bugId].hunter;
-        require(msg.sender == turn);
-        address defendant = proposalCount[projectId][bugId] % 2 == 1 ? projects[projectId].owner : bugs[projectId][bugId].hunter;
-        bytes32 bugHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugId));
-        bytes32 arbitrationHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugHash));
-        sendToObject(msg.sender, arbitrationHash, arbitrationFee);
-        arbitrations[projectId][bugId] = Arbitration(msg.sender,defendant,now,0);
+    function sendToArbitration(bytes32 projectId, bytes32 bugId) public returns(bytes32 arbitrationId){
+        require(proposalCount[bugId] > 1, "Not enough proposals");
+        (address plaintiff, address defendant) = inTurn(projectId, bugId);
+        require(msg.sender == plaintiff, "Invalid Sender");
+        arbitrationId = keccak256(abi.encodePacked(projectId, bugId));
+        sendToObject(msg.sender, arbitrationId, ARBITRATION_FEE);
+        arbitrations[arbitrationId] = Arbitration(msg.sender,defendant,now,0);
     }
 
-    function acceptArbitration(uint256 projectId,uint256 bugId) public {
-        require(proposalCount[projectId][bugId] > 1);
-        require(msg.sender == arbitrations[projectId][bugId].defendant);
-        bytes32 bugHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugId));
-        bytes32 arbitrationHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugHash));
-        sendToObject(msg.sender, arbitrationHash, arbitrationFee);
-        arbitrations[projectId][bugId].commitPeriod = now;
+    function acceptArbitration(bytes32 arbitrationId) public {
+        require(msg.sender == arbitrations[arbitrationId].defendant);
+        sendToObject(msg.sender, arbitrationId, ARBITRATION_FEE);
+        arbitrations[arbitrationId].commitPeriod = now;
     }
 
-    function commitVote(uint256 projectId,uint256 bugId, bytes32 commit) public {
-        Arbitration memory arbitration = arbitrations[projectId][bugId];
+    function commitVote(bytes32 arbitrationId, bytes32 commit) public {
+        Arbitration memory arbitration = arbitrations[arbitrationId];
         require(msg.sender != arbitration.plaintiff && msg.sender != arbitration.defendant, "Invalid voter");
         //require that the voter has any reputation
-        require(arbitration.commitPeriod <= now && now <= arbitration.commitPeriod.add(3 days), "Invalid voting period");
-        bytes32 bugHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugId));
-        bytes32 arbitrationHash = keccak256(abi.encodePacked(projectIdtoHash[projectId], bugHash));
-        sendToObject(msg.sender, arbitrationHash, votingFee);
-        commits[arbitrationHash][msg.sender] = commit;
+        require(arbitration.commitPeriod <= now && now <= arbitration.commitPeriod.add(INTERIM), "Invalid voting period");
+        sendToObject(msg.sender, arbitrationId, VOTING_FEE);
+        commits[arbitrationId][msg.sender] = commit;
     }
 
     /**
@@ -250,33 +251,50 @@ contract SolidifiedBugBounty {
 
 
     //getters
-    function getProjectDetails(uint256 projectId) external view returns(address owner, bytes32 infoHash, ProjectStatus status, uint256[5] memory rewards, uint256 totalPool) {
+    function getProjectDetails(bytes32 projectId)
+        external
+        view
+        returns(address owner, bytes32 infoHash, ProjectStatus status, uint256[5] memory rewards, uint256 totalPool) {
         Project memory p = projects[projectId];
         owner = p.owner;
         infoHash = p.infoHash;
         status = p.status;
-        rewards = [projects[projectId].rewards[0],projects[projectId].rewards[1],projects[projectId].rewards[2],projects[projectId].rewards[3],projects[projectId].rewards[4]];
-        totalPool = objectBalances[projectIdtoHash[projectId]];
+        rewards = [
+            projects[projectId].rewards[0],
+            projects[projectId].rewards[1],
+            projects[projectId].rewards[2],
+            projects[projectId].rewards[3],
+            projects[projectId].rewards[4] ];
+        totalPool = objectBalances[projectId];
     }
 
-    function getBugDetails(uint256 projectId, uint256 bugId) external view returns(address hunter, uint256 timestamp, BugStatus status, uint256 bugValue) {
-        Bug memory b = bugs[projectId][bugId];
+    function getBugDetails(bytes32 bugId)
+        external
+        view
+        returns(address hunter, uint256 timestamp, BugStatus status, uint256 bugValue) {
+        Bug memory b = bugs[bugId];
         hunter = b.hunter;
         timestamp = b.timestamp;
         status = b.status;
         bugValue = b.value;
     }
 
-    function getLatestProposal(uint256 projectId, uint256 bugId) external view returns(address proponent, uint256 timestamp,Severity severity, bytes32 justification) {
-        Proposal memory p = proposals[projectId][bugId][proposalCount[projectId][bugId]];
+    function getLatestProposal(bytes32 bugId)
+        external
+        view
+        returns(address proponent, uint256 timestamp,Severity severity, bytes32 justification) {
+        Proposal memory p = proposals[bugId][proposalCount[bugId]];
         proponent = p.proponent;
         timestamp = p.timestamp;
         severity = p.severity;
         justification = p.justification;
     }
 
-    function getArbitrationDetails(uint256 projectId, uint256 bugId) external view returns(address plaintiff , address defendant, uint256 timestamp, uint256 commitPeriod) {
-        Arbitration memory a = arbitrations[projectId][bugId];
+    function getArbitrationDetails(bytes32 arbitrationId)
+        external
+        view
+        returns(address plaintiff , address defendant, uint256 timestamp, uint256 commitPeriod) {
+        Arbitration memory a = arbitrations[arbitrationId];
         plaintiff = a.plaintiff;
         defendant = a.defendant;
         timestamp = a.timestamp;
@@ -286,5 +304,10 @@ contract SolidifiedBugBounty {
     //Helper Functions
     function isOrdered(uint256[5] memory _arr) internal pure returns(bool){
         return _arr[0] > _arr[1] && _arr[1] > _arr[2] && _arr[2] > _arr[3] && _arr[3] > _arr[4];
+    }
+
+    function inTurn(bytes32 _projectId, bytes32 _bugId) internal view returns(address first, address second) {
+        first = proposalCount[_bugId] % 2 == 0 ? projects[_projectId].owner : bugs[_bugId].hunter;
+        second = proposalCount[_bugId] % 2 == 1 ? projects[_projectId].owner : bugs[_bugId].hunter;
     }
 }

--- a/contracts/SolidifiedBugBounty.sol
+++ b/contracts/SolidifiedBugBounty.sol
@@ -153,11 +153,11 @@ contract SolidifiedBugBounty {
     function postBug(bytes32 bugDescription, bytes32 projectId, Severity severity) public returns(bytes32 bugId) {
         uint256 bugNumber = bugCount[projectId];
         uint256 bugValue = projects[projectId].rewards[uint256(severity)];
-        bugId = keccak256(abi.encodePacked(projects[projectId], bugNumber));
+        bugId = keccak256(abi.encodePacked(projectId, bugNumber));
         bugs[bugId] = Bug(msg.sender, now, bugValue, BugStatus.pending, severity);
         sendToObject(msg.sender, bugId, bugValue.div(BUG_STAKE));
         __transfer(projectId, bugId, bugValue);
-        bugNumber[projectId] = bugNumber[projectId].add(1);
+        bugCount[projectId] = bugCount[projectId].add(1);
         if(objectBalances[projectId] < projects[projectId].rewards[0]){
             projects[projectId].status = ProjectStatus.unfunded;
         }

--- a/test/solidified.js
+++ b/test/solidified.js
@@ -149,7 +149,12 @@ contract("Solidified Bug Bounty", accounts => {
     });
 
     it("User can pull posted contracts", async () => {
-      const projectId = "1";
+      const projectId = web3.utils.soliditySha3(
+        { t: "address", v: accounts[4] },
+        { t: "uint256", v: 1 }
+      );
+      console.log(projectId);
+
       const totalPool = ether("5");
       const ipfsHash = web3.utils.asciiToHex("Project Info");
       const rewards = [


### PR DESCRIPTION
The contracts are now based on `bytes32` ids, instead of `uint256`. This will allow simpler interfaces and mappings